### PR TITLE
Bump paranoia for required bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ which is automatically installed for you.
 You can optionally install [django-paranoia][2] which will be
 integrated into the session engine. Add it like this:
 
-    pip install 'django-paranoia>=0.1.8.5'
+    pip install 'django-paranoia>=0.1.8.6'
 
 You must install either
 [M2Crypto](https://pypi.python.org/pypi/M2Crypto)

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands=
 deps= mock
 
 [paranoia]
-deps= django-paranoia>=0.1.8.5
+deps= django-paranoia>=0.1.8.6
 
 [pyc]
 deps= pycrypto>=2.0


### PR DESCRIPTION
We just started integrating encrypted_cookies and found a bug in the paranoia lib. I'll let you know when it's stable enough to move to our prod so that you can do a PyPI release.
