### PR TITLE
Drop support for PyCrypto - M2Crypto is now a hard requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,13 @@ integrated into the session engine. Add it like this:
 
     pip install 'django-paranoia>=0.1.8.6'
 
-You must install either
-[pycrypto](https://pypi.python.org/pypi/pycrypto)
-*or* both
-[M2Crypto](https://pypi.python.org/pypi/M2Crypto)
-and [m2secret](https://pypi.python.org/pypi/m2secret).
-Neither of these will be installed automatically.
+django-encrypted-cookie-session uses M2Crypto, which requires SWIG to build,
+so install SWIG before attempting to install django-encrypted-cookie-session:
 
-Get M2Crypto like this:
-
-    # M2Crypto requires swig, install it like this on OS X with MacPorts:
+    # OS X with MacPorts:
     sudo port install swig-python
-    # ...or like this on Debian:
+    # Debian:
     sudo apt-get install swig
-    pip install 'M2Crypto>=0.21.1' 'm2secret>=0.1.1'
-
-or get pycrypto like this:
-
-    pip install 'pycrypto>=2.0'
 
 then install the main package:
 
@@ -158,7 +147,7 @@ need 2.6 as well to run all environments. Run the tests like this:
 
 To run the tests against a single environment:
 
-    tox -e py27-django15-pyc
+    tox -e py27-django15-m2c
 
 To debug something weird, run it directly from the virtualenv like:
 
@@ -166,6 +155,14 @@ To debug something weird, run it directly from the virtualenv like:
 
 Changelog
 =========
+
+2.0.0
+-----
+
+* Drop support for pycrypto to fix
+  https://github.com/brightinteractive/django-encrypted-cookie-session/issues/11
+  and
+  https://github.com/brightinteractive/django-encrypted-cookie-session/issues/12
 
 1.1.1
 -----

--- a/encrypted_cookies/__init__.py
+++ b/encrypted_cookies/__init__.py
@@ -5,6 +5,7 @@ import zlib
 
 from django.conf import settings
 from django.core import signing
+from m2secret import DecryptionError as M2DecryptionError
 try:
     # Django 1.5.x support
     from django.contrib.sessions.serializers import PickleSerializer
@@ -31,14 +32,8 @@ except ImportError:
             raise
     get_paranoid = False
 
-try:
-    import m2secret
-    M2DecryptionError = m2secret.DecryptionError
-except ImportError:
-    class M2DecryptionError(Exception):
-        """Stub exception when not using M2Crypto."""
 
-__version__ = '1.1.1'
+__version__ = '2.0.0'
 
 log = logging.getLogger(__name__)
 

--- a/encrypted_cookies/crypto.py
+++ b/encrypted_cookies/crypto.py
@@ -1,34 +1,8 @@
 # -*- coding: utf-8 -*-
 # (c) 2013 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
-import hashlib
-import sys
-import traceback
-
 from django.conf import settings
-
-# Use M2Crypto or pycrypto, whichever we find first.
-m2c_exc = None
-use_m2crypto = False
-try:
-    from m2secret import Secret
-    use_m2crypto = True
-except ImportError:
-    m2c_exc = sys.exc_info()
-
-pyc_exc = None
-use_pycrypto = False
-try:
-    from Crypto.Cipher import AES
-    use_pycrypto = True
-except ImportError:
-    pyc_exc = sys.exc_info()
-
-if not use_pycrypto and not use_m2crypto:
-    traceback.print_exception(*m2c_exc)
-    traceback.print_exception(*pyc_exc)
-    raise ImportError('there was a problem importing either m2secret, '
-                      'M2Crypto, or pycrypto')
+from m2secret import Secret
 
 
 def encrypted_cookie_key():
@@ -38,39 +12,17 @@ def encrypted_cookie_key():
     return key
 
 
-def pycrypto_cipher():
-    # compute a 32-byte key
-    key = hashlib.sha256(encrypted_cookie_key()).digest()
-    assert len(key) == 32
-    # compute a 16-byte IV
-    IV = hashlib.md5(encrypted_cookie_key()).digest()
-    assert len(IV) == 16
-
-    # create an AES cipher, use CFB mode so we don't have to worry about
-    # padding
-    cipher = AES.new(key, AES.MODE_CFB, IV)
-    return cipher
-
-
 def encrypt(plaintext_bytes):
     key = encrypted_cookie_key()
     if not key:
         raise ValueError('The ENCRYPTED_COOKIE_KEY and SECRET_KEY settings must not both be empty.')
 
-    if use_m2crypto:
-        secret = Secret()
-        secret.encrypt(plaintext_bytes, key)
-        return secret.serialize()
-    else:
-        cipher = pycrypto_cipher()
-        return cipher.encrypt(plaintext_bytes)
+    secret = Secret()
+    secret.encrypt(plaintext_bytes, key)
+    return secret.serialize()
 
 
 def decrypt(encrypted_bytes):
-    if use_m2crypto:
-        secret = Secret()
-        secret.deserialize(encrypted_bytes)
-        return secret.decrypt(encrypted_cookie_key())
-    else:
-        cipher = pycrypto_cipher()
-        return cipher.decrypt(encrypted_bytes)
+    secret = Secret()
+    secret.deserialize(encrypted_bytes)
+    return secret.decrypt(encrypted_cookie_key())

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ url = 'http://github.com/brightinteractive/django-encrypted-cookie-session/'
 author = 'Bright Interactive'
 author_email = 'francis@bright-interactive.co.uk'
 license = 'BSD'
-install_requires = ['Django>=1.4']
+install_requires = [
+    'Django>=1.4',
+    'M2Crypto>=0.21.1',
+    'm2secret>=0.1.1',
+]
 
 
 def get_version(package):

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
 envlist=
-    py26-django14-pyc,
     py26-django14-m2c,
-    py27-django14-pyc,
     py27-django14-m2c,
-    py26-django15-pyc,
     py26-django15-m2c,
-    py27-django15-pyc,
     py27-django15-m2c,
     py27-django15-m2c-noparanoia,
 
@@ -19,9 +15,6 @@ deps= mock
 
 [paranoia]
 deps= django-paranoia>=0.1.8.6
-
-[pyc]
-deps= pycrypto>=2.0
 
 [m2c]
 deps=
@@ -38,27 +31,11 @@ deps=
     Django>=1.5,<1.6
     {[base]deps}
 
-# Python 2.6 + Django 1.4
-[testenv:py26-django14-pyc]
-basepython=python2.6
-deps=
-    {[django14]deps}
-    {[pyc]deps}
-    {[paranoia]deps}
-
 [testenv:py26-django14-m2c]
 basepython=python2.6
 deps=
     {[django14]deps}
     {[m2c]deps}
-    {[paranoia]deps}
-
-# Python 2.7 + Django 1.4
-[testenv:py27-django14-pyc]
-basepython=python2.7
-deps=
-    {[django14]deps}
-    {[pyc]deps}
     {[paranoia]deps}
 
 [testenv:py27-django14-m2c]
@@ -68,27 +45,11 @@ deps=
     {[m2c]deps}
     {[paranoia]deps}
 
-# Python 2.6 + Django 1.5
-[testenv:py26-django15-pyc]
-basepython=python2.6
-deps=
-    {[django15]deps}
-    {[pyc]deps}
-    {[paranoia]deps}
-
 [testenv:py26-django15-m2c]
 basepython=python2.6
 deps=
     {[django15]deps}
     {[m2c]deps}
-    {[paranoia]deps}
-
-# Python 2.7 + Django 1.5
-[testenv:py27-django15-pyc]
-basepython=python2.7
-deps=
-    {[django15]deps}
-    {[pyc]deps}
     {[paranoia]deps}
 
 [testenv:py27-django15-m2c]


### PR DESCRIPTION
There were some security flaws in the way we used PyCrypto. We could have changed our use of PyCrypto to be more secure, but it seems more efficient to drop support for PyCrypto rather than maintain two different crypto backends. M2Crypto has more batteries included, so using it instead of PyCrypto is more in keeping with the "leave security to the experts" approach.

Fixes #11 and #12.
