### PR TITLE
Port to cryptography (fixes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Django Encrypted Session Cookie
+Django Encrypted Session Cookie
+===============================
 
 Out of the box Django lets you run sessions with
 [signed cookies](https://docs.djangoproject.com/en/dev/topics/http/sessions/#using-cookie-based-sessions).
@@ -12,52 +13,24 @@ handing to the client.
 
 **Author:** Francis Devereux, [Bright Interactive][1].
 
-# Adding it to your Django Project
+Adding it to your Django Project
+================================
 
+Here are some installation commands you can follow using the
+[pip](http://www.pip-installer.org/) installer.
 You'll need
 [Django](https://djangoproject.com/) 1.4.x or greater (tested through 1.8)
-and
-Python 2.6 or higher. Python 3 is currently untested.
-You'll also need to install a backend for the actual cryptographic operations.
-See the section on backends for their respective installation instructions.
+and [cryptography](https://cryptography.io/en/latest/)
+which are both automatically installed for you.
+Python 2.6 or higher is supported but Python 3 is untested.
 
-Install the module and its dependencies with [pip](http://www.pip-installer.org/):
+Install the module and its dependencies with pip:
 
     pip install django-encrypted-cookie-session
 
 Activate the session engine by putting this in your Django settings:
 
     SESSION_ENGINE = 'encrypted_cookies'
-
-See the instructions on your chosen backend for how to configure
-your `ENCRYPTED_COOKIE_KEYS` setting.
-
-Beware! If you don't use an HTTPS URL for local development
-(you probably don't) then you may need to set this:
-
-    SESSION_COOKIE_SECURE = False
-
-Without it you might see a KeyError for session data because it
-won't be saving properly. Obviously, in production where you use
-an HTTPS URL you should make sure cookies are always secure.
-
-# Crypto Backends
-
-The following are the available backends you can use for
-cryptographic operations. You need to install at least one.
-
-## Cryptography
-
-### Installation and configuration
-
-The [cryptography](https://cryptography.io/en/latest/) backend
-is the default. Install it with pip like this:
-
-    pip install 'cryptography>=0.7'
-
-You can explicitly activate it with this setting:
-
-    ENCRYPTED_COOKIE_BACKEND = 'cryptography'
 
 When you install `django-encrypted-cookie-session` you also get
 the `encrypted-cookies-keygen` command. Run this to generate a key
@@ -70,7 +43,17 @@ Add it to your Django settings:
 
     ENCRYPTED_COOKIE_KEYS = ['VDIXZGQS3fiJwG93Ha2jYZGZkxcqGDY3m-nZI3fha48=']
 
-### Key Rotation
+Beware! If you don't use an HTTPS URL for local development
+(you probably don't) then you may need to set this:
+
+    SESSION_COOKIE_SECURE = False
+
+Without it you might see a KeyError for session data because it
+won't be saving properly. Obviously, in production where you use
+an HTTPS URL you should make sure cookies are always secure.
+
+Key Rotation
+============
 
 For added protection, you can rotate your encryption keys whenever
 you like. When you add a new key, you may wish to include the old
@@ -90,39 +73,8 @@ Any time a user makes a request to a Django view that alters the session,
 the cookie will be re-encrypted in the response.
 Thus, you can safely remove old keys soon after you deploy a new key.
 
-## M2Crypto
-
-### Installation and Configuration
-
-[M2Crypto](https://github.com/martinpaljak/M2Crypto/)
-requires [swig](http://www.swig.org/)
-so first you need to install that with your
-package manager. On Mac OS X with [homebrew](http://brew.sh/) you can do:
-
-    brew install swig
-
-At the time of this writing, there is an
-[open bug](https://github.com/martinpaljak/M2Crypto/issues/60)
-which may require you to downgrade swig or downgrade M2Crypto.
-Version 0.22.1 of M2Crypto is known to work.
-Say a prayer and try to install it:
-
-    pip install 'M2Crypto>=0.22.1'
-
-Activate the backend with this setting:
-
-    ENCRYPTED_COOKIE_BACKEND = 'M2Crypto'
-
-Think of a long secret (preferably longer than 32 bytes)
-and add it to your Django settings:
-
-    ENCRYPTED_COOKIE_KEYS = ['some really long secret']
-
-### Key Rotation
-
-Key rotation is not currently supported in the M2Crypto backend.
-
-# Cookie Size
+Cookie Size
+===========
 
 Most browsers limit cookie size to 4092 bytes (name + value).
 Most servers also have a limit to the request/response header size
@@ -145,7 +97,8 @@ size may also affect network performance. For best results, limit the amount of
 data you store in the session. If you turn on logging, you'll see the byte size
 of each session cookie.
 
-# Logging
+Logging
+=======
 
 This module outputs some logging in the `encrypted_cookies` channel.
 Here is a settings example for enabling logging in Django:
@@ -159,7 +112,8 @@ Here is a settings example for enabling logging in Django:
         }
     }
 
-# Debugging
+Debugging
+=========
 
 If you need to debug an issue with sessions on a live system,
 you can open a Python shell on the server and decrypt a cookie like this:
@@ -170,7 +124,8 @@ you can open a Python shell on the server and decrypt a cookie like this:
     signing.loads("<cookie_value>", salt='encrypted_cookies', serializer=EncryptingPickleSerializer)
 
 
-# Publishing releases to PyPI
+Publishing releases to PyPI
+===========================
 
 To publish a new version of django-validate-on-save to PyPI, set the
 `__version__` string in `encrypted_cookies/__init__.py`, then run:
@@ -184,7 +139,8 @@ To publish a new version of django-validate-on-save to PyPI, set the
     git push --tags
 
 
-# Running the tests
+Running the tests
+=================
 
 To run the tests against multiple environments, install
 [tox](http://tox.readthedocs.org/) using
@@ -201,40 +157,40 @@ To debug something weird, run it directly from the virtualenv like:
 
     .tox/py27-django18/bin/python manage.py test
 
-If you are having trouble with the cryptography module, see the
-[installation docs](https://cryptography.io/en/latest/installation/) for tips.
-You may need to specify your openssl path.
+Changelog
+=========
 
-# Changelog
+3.0.0
+-----
 
-## 3.0.0
-
-* Added configurable backends.
-* Added support for [cryptography](https://cryptography.io/en/latest/).
-* **BREAKING CHANGE**: `cryptography` is the default backend so if you
-  want your old configuration to "just work" you need to set
-  `ENCRYPTED_COOKIE_BACKEND = 'M2Crypto'`.
-* **BREAKING CHANGE**: Removed support for
+* Dropped support for [M2Crypto](https://pypi.python.org/pypi/M2Crypto)
+  in favor of [cryptography](https://cryptography.io/en/latest/) for
+  better platform support.
+* **BREAKING CHANGE**: Old values from the `ENCRYPTED_COOKIE_KEY` setting
+  no longer work because key formatting changed. You must generate a new
+  key with the provided command and define it in the list setting like
+  `ENCRYPTED_COOKIE_KEYS = [...]`.
+* **BREAKING CHANGE**: The Django `SECRET_KEY` setting can no longer be
+  used as a fallback. Define `ENCRYPTED_COOKIE_KEYS = [...]` instead.
+* Removed support for
   [django-paranoia](https://django-paranoia.readthedocs.org/en/latest/)
   because its core features are included with Django now.
-* **DEPRECATED**: to prepare for key rotation, the `ENCRYPTED_COOKIE_KEY`
-  setting is deprecated in favor or `ENCRYPTED_COOKIE_KEYS = [...]`.
-* **DEPRECATED**: falling back to the Django `SECRET_KEY` setting is
-  deprecated. Define `ENCRYPTED_COOKIE_KEYS = [...]` instead.
-* Updated tests to cover Django through version 1.8.
 
-## 2.0.0
+2.0.0
+-----
 
 * Drop support for pycrypto to fix
   https://github.com/brightinteractive/django-encrypted-cookie-session/issues/11
   and
   https://github.com/brightinteractive/django-encrypted-cookie-session/issues/12
 
-## 1.1.1
+1.1.1
+-----
 
 * Fix ImportError with Django 1.5.3+
 
-## 1.1.0
+1.1.0
+-----
 
 * Added optional `ENCRYPTED_COOKIE_KEY` in addition to `SECRET_KEY` to encourage
   care and isolation of the key. You do not need to add `ENCRYPTED_COOKIE_KEY` to
@@ -245,11 +201,13 @@ You may need to specify your openssl path.
 * Added more test coverage
 * Compress cookie value before encrypting
 
-## 1.0.0
+1.0.0
+-----
 
 * Initial release
 
-# License
+License
+=======
 
 Copyright (c) Bright Interactive Limited.
 Started with django-reusable-app Copyright (c) DabApps.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Install the module and its dependencies with pip:
 
     pip install django-encrypted-cookie-session
 
+If you have any trouble with the cryptography module, read through
+their [installation docs](https://cryptography.io/en/latest/installation/)
+for tips.
+
 Activate the session engine by putting this in your Django settings:
 
     SESSION_ENGINE = 'encrypted_cookies'

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ Changelog
 * Dropped support for [M2Crypto](https://pypi.python.org/pypi/M2Crypto)
   in favor of [cryptography](https://cryptography.io/en/latest/) for
   better platform support.
+* **BREAKING CHANGE**: Old values from the `ENCRYPTED_COOKIE_KEY` setting
+  no longer work because key formatting changed. You must generate a new
+  key with the provided command and define it in the list setting like
+  `ENCRYPTED_COOKIE_KEYS = [...]`.
 * **BREAKING CHANGE**: The Django `SECRET_KEY` setting can no longer be
   used as a fallback. Define `ENCRYPTED_COOKIE_KEYS = [...]` instead.
-* **DEPRECATED**: The Django `ENCRYPTED_COOKIE_KEY` setting is deprecated.
-  Use `ENCRYPTED_COOKIE_KEYS = [...]` instead.
-* You cannot reuse your old `ENCRYPTED_COOKIE_KEY` value because the key
-  format has changed. You must generate a new key using the provided command.
 * Removed support for
   [django-paranoia](https://django-paranoia.readthedocs.org/en/latest/)
   because its core features are included with Django now.

--- a/encrypted_cookies/__init__.py
+++ b/encrypted_cookies/__init__.py
@@ -18,8 +18,6 @@ try:
 except ImportError:
     import pickle
 
-from cryptography.fernet import InvalidToken
-
 from encrypted_cookies import crypto
 
 __version__ = '3.0.0'
@@ -67,7 +65,7 @@ class SessionStore(django.contrib.sessions.backends.signed_cookies.SessionStore)
                 max_age=settings.SESSION_COOKIE_AGE,
                 salt='encrypted_cookies')
         except (signing.BadSignature, pickle.UnpicklingError,
-                InvalidToken, ValueError), exc:
+                crypto.DecryptionError, ValueError), exc:
             log.debug('recreating session because of exception: %s: %s'
                       % (exc.__class__.__name__, exc))
             self.create()

--- a/encrypted_cookies/__init__.py
+++ b/encrypted_cookies/__init__.py
@@ -1,40 +1,28 @@
 # -*- coding: utf-8 -*-
 # (c) 2013 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
+import logging
 import zlib
 
+import django.contrib.sessions.backends.signed_cookies
 from django.conf import settings
-from django.core import signing
-from m2secret import DecryptionError as M2DecryptionError
 try:
     # Django 1.5.x support
     from django.contrib.sessions.serializers import PickleSerializer
 except ImportError:
     # Legacy Django support
     from django.contrib.sessions.backends.signed_cookies import PickleSerializer
-import django.contrib.sessions.backends.signed_cookies
-import logging
-
-from encrypted_cookies import crypto
+from django.core import signing
 try:
     from django.utils.six.moves import cPickle as pickle
 except ImportError:
     import pickle
 
-try:
-    import django_paranoia.sessions
-    get_paranoid = True
-except ImportError:
-    for mc in settings.MIDDLEWARE_CLASSES:
-        if 'django_paranoia' in mc:
-            # This means we probably hit a legitimate ImportError
-            # so re-raise it.
-            raise
-    get_paranoid = False
+from cryptography.fernet import InvalidToken
 
+from encrypted_cookies import crypto
 
-__version__ = '2.0.0'
-
+__version__ = '3.0.0'
 log = logging.getLogger(__name__)
 
 
@@ -64,25 +52,7 @@ class EncryptingPickleSerializer(PickleSerializer):
         return super(EncryptingPickleSerializer, self).loads(decrypted_data)
 
 
-if get_paranoid:
-    # Django paranoia unfortunately collides with some session logic
-    # so we need to integrate the two together.
-    class BaseSessionStore(
-            django.contrib.sessions.backends.signed_cookies.SessionStore,
-            django_paranoia.sessions.SessionStore):
-
-        def save(self, must_create=False):
-            # Run django_paranoia pre-save logic.
-            self.prepare_data(must_create=must_create)
-            # Run the actual save logic from signed cookies.
-            return super(BaseSessionStore, self).save(must_create=must_create)
-else:
-    class BaseSessionStore(
-            django.contrib.sessions.backends.signed_cookies.SessionStore):
-        pass
-
-
-class SessionStore(BaseSessionStore):
+class SessionStore(django.contrib.sessions.backends.signed_cookies.SessionStore):
 
     def load(self):
         """
@@ -97,7 +67,9 @@ class SessionStore(BaseSessionStore):
                 max_age=settings.SESSION_COOKIE_AGE,
                 salt='encrypted_cookies')
         except (signing.BadSignature, pickle.UnpicklingError,
-                M2DecryptionError, ValueError):
+                InvalidToken, ValueError), exc:
+            log.debug('recreating session because of exception: %s: %s'
+                      % (exc.__class__.__name__, exc))
             self.create()
         return {}
 

--- a/encrypted_cookies/__init__.py
+++ b/encrypted_cookies/__init__.py
@@ -18,6 +18,8 @@ try:
 except ImportError:
     import pickle
 
+from cryptography.fernet import InvalidToken
+
 from encrypted_cookies import crypto
 
 __version__ = '3.0.0'
@@ -65,7 +67,7 @@ class SessionStore(django.contrib.sessions.backends.signed_cookies.SessionStore)
                 max_age=settings.SESSION_COOKIE_AGE,
                 salt='encrypted_cookies')
         except (signing.BadSignature, pickle.UnpicklingError,
-                crypto.DecryptionError, ValueError), exc:
+                InvalidToken, ValueError), exc:
             log.debug('recreating session because of exception: %s: %s'
                       % (exc.__class__.__name__, exc))
             self.create()

--- a/encrypted_cookies/crypto.py
+++ b/encrypted_cookies/crypto.py
@@ -8,8 +8,6 @@ from django.core.exceptions import ImproperlyConfigured
 
 from  cryptography import fernet
 
-log = logging.getLogger(__name__)
-
 
 def encrypt(plaintext_bytes):
     """
@@ -29,13 +27,6 @@ def decrypt(encrypted_bytes):
 
 def configure_fernet():
     keys = list(getattr(settings, 'ENCRYPTED_COOKIE_KEYS', None) or [])
-    if not len(keys):
-        old_key = getattr(settings, 'ENCRYPTED_COOKIE_KEY', None)
-        if old_key:
-            log.warning('ENCRYPTED_COOKIE_KEY setting is deprecated. '
-                        'Use ENCRYPTED_COOKIE_KEYS=[...]')
-            keys.append(old_key)
-
     if not len(keys):
         raise ImproperlyConfigured(
             'The ENCRYPTED_COOKIE_KEYS settings cannot be empty.')

--- a/encrypted_cookies/crypto.py
+++ b/encrypted_cookies/crypto.py
@@ -2,11 +2,12 @@
 # (c) 2013 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
 import logging
+import sys
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from  cryptography import fernet
+log = logging.getLogger(__name__)
 
 
 def encrypt(plaintext_bytes):
@@ -15,20 +16,131 @@ def encrypt(plaintext_bytes):
 
     The encrypted value is a URL-encoded base 64 value.
     """
-    return configure_fernet().encrypt(plaintext_bytes)
+    return get_backend().encrypt(plaintext_bytes)
 
 
 def decrypt(encrypted_bytes):
     """
     Returns a decrypted version of encrypted_bytes.
     """
-    return configure_fernet().decrypt(encrypted_bytes)
+    return get_backend().decrypt(encrypted_bytes)
 
 
-def configure_fernet():
-    keys = list(getattr(settings, 'ENCRYPTED_COOKIE_KEYS', None) or [])
-    if not len(keys):
+class DecryptionError(Exception):
+    """
+    An error while decrypting data such as a malformed token.
+    """
+
+
+default_backend = 'cryptography'
+backend_lookup = {}
+
+
+def get_backend():
+    module_name = (getattr(settings, 'ENCRYPTED_COOKIE_BACKEND', None) or
+                   default_backend)
+    Backend = backend_lookup.get(module_name, None)
+    if not Backend:
         raise ImproperlyConfigured(
-            'The ENCRYPTED_COOKIE_KEYS settings cannot be empty.')
+            'No backend exists for module named "%s"; possible backends: %s'
+            % (module_name, repr(backend_lookup.keys())))
 
-    return fernet.MultiFernet([fernet.Fernet(k) for k in keys])
+    return Backend()
+
+
+def register_backend(cls):
+    backend_lookup[cls.module_name] = cls
+    return cls
+
+
+class EncryptedCookieBackend(object):
+    module_name = None
+
+    def __init__(self):
+        self.keys = self.get_keys()
+        if not len(self.keys):
+            raise ImproperlyConfigured(
+                '%s: The ENCRYPTED_COOKIE_KEYS setting cannot be empty.'
+                % self.__class__.__name__)
+
+    def get_keys(self):
+        return list(getattr(settings, 'ENCRYPTED_COOKIE_KEYS', None) or [])
+
+    def encrypt(self, plaintext_bytes):
+        raise NotImplementedError
+
+    def decrypt(self, encrypted_bytes):
+        raise NotImplementedError
+
+
+@register_backend
+class CryptographyBackend(EncryptedCookieBackend):
+    module_name = 'cryptography'
+
+    def __init__(self):
+        super(CryptographyBackend, self).__init__()
+        from cryptography.fernet import Fernet, MultiFernet
+        self.fernet = MultiFernet([Fernet(k) for k in self.keys])
+
+    def encrypt(self, plaintext_bytes):
+        return self.fernet.encrypt(plaintext_bytes)
+
+    def decrypt(self, encrypted_bytes):
+        from cryptography.fernet import InvalidToken
+        try:
+            return self.fernet.decrypt(encrypted_bytes)
+        except InvalidToken:
+            exc_type, exc_value, tb = sys.exc_info()
+            new_exc = DecryptionError('%s: %s' % (exc_type.__name__, exc_value))
+            raise new_exc, None, tb
+
+
+@register_backend
+class M2CryptoBackend(EncryptedCookieBackend):
+    module_name = 'M2Crypto'
+
+    def __init__(self):
+        super(M2CryptoBackend, self).__init__()
+        from m2secret import Secret
+
+        if len(self.keys) > 1:
+            raise NotImplementedError(
+                '%s: cannot define more than one key; rotation not implemented'
+                % self.__class__.__name__)
+
+        self.key = self.keys[0]
+
+        self.secret = Secret()
+
+    def get_keys(self):
+        keys = super(M2CryptoBackend, self).get_keys()
+
+        if not len(keys):
+            old_key = getattr(settings, 'ENCRYPTED_COOKIE_KEY', None)
+            if old_key:
+                log.warning('The ENCRYPTED_COOKIE_KEY setting is deprecated; '
+                            'define ENCRYPTED_COOKIE_KEYS=[...] instead.')
+                keys.append(old_key)
+
+        if not len(keys):
+            django_key = getattr(settings, 'SECRET_KEY', '')
+            if django_key:
+                log.warning('Falling back to the SECRET_KEY setting is deprecated; '
+                            'define ENCRYPTED_COOKIE_KEYS=[...] instead.')
+                keys.append(django_key)
+
+        return keys
+
+    def encrypt(self, plaintext_bytes):
+        self.secret.encrypt(plaintext_bytes, self.key)
+        return self.secret.serialize()
+
+    def decrypt(self, encrypted_bytes):
+        import m2secret
+        try:
+            self.secret.deserialize(encrypted_bytes)
+            return self.secret.decrypt(self.key)
+        except m2secret.DecryptionError:
+            exc_type, exc_value, tb = sys.exc_info()
+            new_exc = DecryptionError('%s: %s' % (exc_type.__name__, exc_value))
+            raise new_exc, None, tb

--- a/encrypted_cookies/crypto.py
+++ b/encrypted_cookies/crypto.py
@@ -2,12 +2,11 @@
 # (c) 2013 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
 import logging
-import sys
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-log = logging.getLogger(__name__)
+from  cryptography import fernet
 
 
 def encrypt(plaintext_bytes):
@@ -16,131 +15,20 @@ def encrypt(plaintext_bytes):
 
     The encrypted value is a URL-encoded base 64 value.
     """
-    return get_backend().encrypt(plaintext_bytes)
+    return configure_fernet().encrypt(plaintext_bytes)
 
 
 def decrypt(encrypted_bytes):
     """
     Returns a decrypted version of encrypted_bytes.
     """
-    return get_backend().decrypt(encrypted_bytes)
+    return configure_fernet().decrypt(encrypted_bytes)
 
 
-class DecryptionError(Exception):
-    """
-    An error while decrypting data such as a malformed token.
-    """
-
-
-default_backend = 'cryptography'
-backend_lookup = {}
-
-
-def get_backend():
-    module_name = (getattr(settings, 'ENCRYPTED_COOKIE_BACKEND', None) or
-                   default_backend)
-    Backend = backend_lookup.get(module_name, None)
-    if not Backend:
+def configure_fernet():
+    keys = list(getattr(settings, 'ENCRYPTED_COOKIE_KEYS', None) or [])
+    if not len(keys):
         raise ImproperlyConfigured(
-            'No backend exists for module named "%s"; possible backends: %s'
-            % (module_name, repr(backend_lookup.keys())))
+            'The ENCRYPTED_COOKIE_KEYS settings cannot be empty.')
 
-    return Backend()
-
-
-def register_backend(cls):
-    backend_lookup[cls.module_name] = cls
-    return cls
-
-
-class EncryptedCookieBackend(object):
-    module_name = None
-
-    def __init__(self):
-        self.keys = self.get_keys()
-        if not len(self.keys):
-            raise ImproperlyConfigured(
-                '%s: The ENCRYPTED_COOKIE_KEYS setting cannot be empty.'
-                % self.__class__.__name__)
-
-    def get_keys(self):
-        return list(getattr(settings, 'ENCRYPTED_COOKIE_KEYS', None) or [])
-
-    def encrypt(self, plaintext_bytes):
-        raise NotImplementedError
-
-    def decrypt(self, encrypted_bytes):
-        raise NotImplementedError
-
-
-@register_backend
-class CryptographyBackend(EncryptedCookieBackend):
-    module_name = 'cryptography'
-
-    def __init__(self):
-        super(CryptographyBackend, self).__init__()
-        from cryptography.fernet import Fernet, MultiFernet
-        self.fernet = MultiFernet([Fernet(k) for k in self.keys])
-
-    def encrypt(self, plaintext_bytes):
-        return self.fernet.encrypt(plaintext_bytes)
-
-    def decrypt(self, encrypted_bytes):
-        from cryptography.fernet import InvalidToken
-        try:
-            return self.fernet.decrypt(encrypted_bytes)
-        except InvalidToken:
-            exc_type, exc_value, tb = sys.exc_info()
-            new_exc = DecryptionError('%s: %s' % (exc_type.__name__, exc_value))
-            raise new_exc, None, tb
-
-
-@register_backend
-class M2CryptoBackend(EncryptedCookieBackend):
-    module_name = 'M2Crypto'
-
-    def __init__(self):
-        super(M2CryptoBackend, self).__init__()
-        from m2secret import Secret
-
-        if len(self.keys) > 1:
-            raise NotImplementedError(
-                '%s: cannot define more than one key; rotation not implemented'
-                % self.__class__.__name__)
-
-        self.key = self.keys[0]
-
-        self.secret = Secret()
-
-    def get_keys(self):
-        keys = super(M2CryptoBackend, self).get_keys()
-
-        if not len(keys):
-            old_key = getattr(settings, 'ENCRYPTED_COOKIE_KEY', None)
-            if old_key:
-                log.warning('The ENCRYPTED_COOKIE_KEY setting is deprecated; '
-                            'define ENCRYPTED_COOKIE_KEYS=[...] instead.')
-                keys.append(old_key)
-
-        if not len(keys):
-            django_key = getattr(settings, 'SECRET_KEY', '')
-            if django_key:
-                log.warning('Falling back to the SECRET_KEY setting is deprecated; '
-                            'define ENCRYPTED_COOKIE_KEYS=[...] instead.')
-                keys.append(django_key)
-
-        return keys
-
-    def encrypt(self, plaintext_bytes):
-        self.secret.encrypt(plaintext_bytes, self.key)
-        return self.secret.serialize()
-
-    def decrypt(self, encrypted_bytes):
-        import m2secret
-        try:
-            self.secret.deserialize(encrypted_bytes)
-            return self.secret.decrypt(self.key)
-        except m2secret.DecryptionError:
-            exc_type, exc_value, tb = sys.exc_info()
-            new_exc = DecryptionError('%s: %s' % (exc_type.__name__, exc_value))
-            raise new_exc, None, tb
+    return fernet.MultiFernet([fernet.Fernet(k) for k in keys])

--- a/encrypted_cookies/crypto.py
+++ b/encrypted_cookies/crypto.py
@@ -1,28 +1,43 @@
 # -*- coding: utf-8 -*-
 # (c) 2013 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
+import logging
+
 from django.conf import settings
-from m2secret import Secret
+from django.core.exceptions import ImproperlyConfigured
 
+from  cryptography import fernet
 
-def encrypted_cookie_key():
-    key = getattr(settings, 'ENCRYPTED_COOKIE_KEY', None)
-    if not key:
-        key = settings.SECRET_KEY
-    return key
+log = logging.getLogger(__name__)
 
 
 def encrypt(plaintext_bytes):
-    key = encrypted_cookie_key()
-    if not key:
-        raise ValueError('The ENCRYPTED_COOKIE_KEY and SECRET_KEY settings must not both be empty.')
+    """
+    Returns an ecnrypted version of plaintext_bytes.
 
-    secret = Secret()
-    secret.encrypt(plaintext_bytes, key)
-    return secret.serialize()
+    The encrypted value is a URL-encoded base 64 value.
+    """
+    return configure_fernet().encrypt(plaintext_bytes)
 
 
 def decrypt(encrypted_bytes):
-    secret = Secret()
-    secret.deserialize(encrypted_bytes)
-    return secret.decrypt(encrypted_cookie_key())
+    """
+    Returns a decrypted version of encrypted_bytes.
+    """
+    return configure_fernet().decrypt(encrypted_bytes)
+
+
+def configure_fernet():
+    keys = list(getattr(settings, 'ENCRYPTED_COOKIE_KEYS', None) or [])
+    if not len(keys):
+        old_key = getattr(settings, 'ENCRYPTED_COOKIE_KEY', None)
+        if old_key:
+            log.warning('ENCRYPTED_COOKIE_KEY setting is deprecated. '
+                        'Use ENCRYPTED_COOKIE_KEYS=[...]')
+            keys.append(old_key)
+
+    if not len(keys):
+        raise ImproperlyConfigured(
+            'The ENCRYPTED_COOKIE_KEYS settings cannot be empty.')
+
+    return fernet.MultiFernet([fernet.Fernet(k) for k in keys])

--- a/encrypted_cookies/keygen.py
+++ b/encrypted_cookies/keygen.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Bright Interactive Limited. All rights reserved.
+# http://www.bright-interactive.com | info@bright-interactive.com
+import optparse
+import sys
+
+from  cryptography.fernet import Fernet
+
+
+def main(stdout=sys.stdout, argv=sys.argv[1:]):
+    p = optparse.OptionParser(
+        usage='%prog [options]\n\n'
+              'Generates a suitable value to put in '
+              'your ENCRYPTED_COOKIE_KEYS=[...] setting.')
+    (options, args) = p.parse_args(argv)
+    stdout.write(Fernet.generate_key())
+
+
+if __name__ == '__main__':
+    main()

--- a/encrypted_cookies/tests.py
+++ b/encrypted_cookies/tests.py
@@ -34,7 +34,7 @@ class EncryptionTests(Base):
     def setUp(self):
         self.pkl = EncryptingPickleSerializer()
 
-    @override_settings(ENCRYPTED_COOKIE_KEYS=None, ENCRYPTED_COOKIE_KEY='')
+    @override_settings(ENCRYPTED_COOKIE_KEYS=None)
     def test_empty_key_not_allowed(self):
         with self.assertRaises(ImproperlyConfigured):
             self.pkl.dumps('summat')
@@ -43,14 +43,6 @@ class EncryptionTests(Base):
         plaintext_bytes = 'adsfasdfw34wras'
         encrypted = self.pkl.dumps(plaintext_bytes)
         self.assertNotEqual(plaintext_bytes, encrypted)
-        decrypted = self.pkl.loads(encrypted)
-        self.assertEqual(plaintext_bytes, decrypted)
-
-    @override_settings(ENCRYPTED_COOKIE_KEYS=None,
-                       ENCRYPTED_COOKIE_KEY=Fernet.generate_key())
-    def test_fall_back_to_old_key_setting(self):
-        plaintext_bytes = 'adsfasdfw34wras'
-        encrypted = self.pkl.dumps(plaintext_bytes)
         decrypted = self.pkl.loads(encrypted)
         self.assertEqual(plaintext_bytes, decrypted)
 

--- a/encrypted_cookies/tests.py
+++ b/encrypted_cookies/tests.py
@@ -69,7 +69,6 @@ class EncryptionTests(Base):
         self.assertEqual(plaintext_bytes, decrypted)
 
 
-@override_settings(ENCRYPTED_COOKIE_KEYS=[Fernet.generate_key()])
 class SessionStoreTests(Base):
 
     def setUp(self):

--- a/encrypted_cookies/tests.py
+++ b/encrypted_cookies/tests.py
@@ -18,6 +18,7 @@ from cryptography.fernet import Fernet
 import mock
 
 from encrypted_cookies import (
+    crypto,
     keygen,
     EncryptingPickleSerializer,
     SessionStore,
@@ -29,15 +30,10 @@ class Base(TestCase):
     pass
 
 
-class EncryptionTests(Base):
+class CookieEncryptionTests(Base):
 
     def setUp(self):
         self.pkl = EncryptingPickleSerializer()
-
-    @override_settings(ENCRYPTED_COOKIE_KEYS=None)
-    def test_empty_key_not_allowed(self):
-        with self.assertRaises(ImproperlyConfigured):
-            self.pkl.dumps('summat')
 
     def test_encrypt_decrypt(self):
         plaintext_bytes = 'adsfasdfw34wras'
@@ -46,10 +42,14 @@ class EncryptionTests(Base):
         decrypted = self.pkl.loads(encrypted)
         self.assertEqual(plaintext_bytes, decrypted)
 
-    @override_settings(ENCRYPTED_COOKIE_KEYS=['nope'])
-    def test_incorrect_key_value(self):
-        with self.assertRaises(ValueError):
-            self.pkl.dumps('summat')
+    def test_default_backend(self):
+        backend = crypto.get_backend()
+        self.assertEqual(backend.module_name, 'cryptography')
+
+    @override_settings(ENCRYPTED_COOKIE_BACKEND='nopenotreally')
+    def test_unknown_backend(self):
+        with self.assertRaises(ImproperlyConfigured):
+            crypto.get_backend()
 
     @override_settings(COMPRESS_ENCRYPTED_COOKIE=True)
     def test_compressed_encrypt_decrypt(self):
@@ -82,7 +82,7 @@ class SessionStoreTests(Base):
         stor = self.sess.load()
         self.assertEqual(stor['secret'], 'laser beams')
 
-    def test_wrong_key(self):
+    def test_wrong_key_resets_session(self):
         with self.settings(ENCRYPTED_COOKIE_KEYS=[Fernet.generate_key()]):
             self.sess['secret'] = 'laser beams'
             self.sess.save()
@@ -91,19 +91,6 @@ class SessionStoreTests(Base):
 
         # The decryption error is ignored and the session is reset.
         self.assertEqual(dict(stor.items()), {})
-
-    def test_key_rotation(self):
-        key1 = Fernet.generate_key()
-
-        with self.settings(ENCRYPTED_COOKIE_KEYS=[key1]):
-            self.sess['secret'] = 'laser beams'
-            self.sess.save()
-        # Decrypt a value using an old key:
-        with self.settings(ENCRYPTED_COOKIE_KEYS=[Fernet.generate_key(),
-                                                  key1]):
-            stor = self.sess.load()
-
-        self.assertEqual(dict(stor.items()), {'secret': 'laser beams'})
 
     @mock.patch('encrypted_cookies.signing.loads')
     def test_bad_signature(self, loader):
@@ -151,3 +138,97 @@ class TestKeygen(TestCase):
         f = Fernet(key)
         # Make sure this doesn't raise an error about a bad key.
         f.decrypt(f.encrypt('whatever'))
+
+
+class BackendTests(Base):
+
+    def setUp(self):
+        self.backend = crypto.get_backend()
+
+
+@override_settings(ENCRYPTED_COOKIE_BACKEND='cryptography')
+class CryptographyTests(BackendTests):
+
+    def test_lookup(self):
+        self.assertEqual(self.backend.module_name, 'cryptography')
+
+    @override_settings(ENCRYPTED_COOKIE_KEYS=None)
+    def test_empty_key_not_allowed(self):
+        with self.assertRaises(ImproperlyConfigured):
+            crypto.get_backend().encrypt('summat')
+
+    def test_encrypt_decrypt(self):
+        message = 'the house key is under the mat'
+        with self.settings(ENCRYPTED_COOKIE_KEYS=[Fernet.generate_key()]):
+            token = self.backend.encrypt(message)
+        self.assertEqual(self.backend.decrypt(token), message)
+
+    @override_settings(ENCRYPTED_COOKIE_KEYS=['nope'])
+    def test_incorrect_key_value(self):
+        with self.assertRaises(ValueError):
+            crypto.get_backend().encrypt('summat')
+
+    @override_settings(ENCRYPTED_COOKIE_KEYS=None,
+                       ENCRYPTED_COOKIE_KEY='some old key')
+    def test_cannot_fall_back_to_old_setting(self):
+        with self.assertRaises(ImproperlyConfigured):
+            crypto.get_backend()
+
+    def test_key_rotation(self):
+        message = 'watch out for feral cats'
+        key1 = Fernet.generate_key()
+
+        with self.settings(ENCRYPTED_COOKIE_KEYS=[key1]):
+            token = crypto.get_backend().encrypt(message)
+
+        # Decrypt a value using an old key:
+        with self.settings(ENCRYPTED_COOKIE_KEYS=[Fernet.generate_key(),
+                                                  key1]):
+            value = crypto.get_backend().decrypt(token)
+
+        self.assertEqual(value, message)
+
+
+@override_settings(ENCRYPTED_COOKIE_BACKEND='M2Crypto',
+                   ENCRYPTED_COOKIE_KEYS=['some long string'])
+class M2CryptoTests(BackendTests):
+
+    def test_lookup(self):
+        self.assertEqual(self.backend.module_name, 'M2Crypto')
+
+    def test_fall_back_to_old_key_setting(self):
+        with self.settings(ENCRYPTED_COOKIE_KEYS=None,
+                           ENCRYPTED_COOKIE_KEY='this is an old key'):
+            backend = crypto.get_backend()
+        backend.decrypt(backend.encrypt('some message'))
+
+    def test_fall_back_to_django_secret_key(self):
+        with self.settings(ENCRYPTED_COOKIE_KEYS=None,
+                           ENCRYPTED_COOKIE_KEY=None,
+                           SECRET_KEY='this is django secret'):
+            backend = crypto.get_backend()
+        backend.decrypt(backend.encrypt('some message'))
+
+    @override_settings(ENCRYPTED_COOKIE_KEYS=None,
+                       ENCRYPTED_COOKIE_KEY=None,
+                       SECRET_KEY='')
+    def test_empty_key_not_allowed(self):
+        with self.assertRaises(ImproperlyConfigured):
+            crypto.get_backend().encrypt('summat')
+
+    @override_settings(ENCRYPTED_COOKIE_KEYS=['key1', 'key2'])
+    def test_key_rotation_not_supported(self):
+        with self.assertRaises(NotImplementedError):
+            crypto.get_backend().encrypt('summat')
+
+    def test_encrypt_decrypt(self):
+        message = 'the house key is under the mat'
+        token = self.backend.encrypt(message)
+        self.assertEqual(self.backend.decrypt(token), message)
+
+    def test_reraise_decryption_errors(self):
+        with self.settings(ENCRYPTED_COOKIE_KEYS=['first key']):
+            token = crypto.get_backend().encrypt('message')
+        with self.assertRaises(crypto.DecryptionError):
+            with self.settings(ENCRYPTED_COOKIE_KEYS=['second key']):
+                crypto.get_backend().decrypt(token)

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,13 @@ author_email = 'francis@bright-interactive.co.uk'
 license = 'BSD'
 install_requires = [
     'Django>=1.4',
-    'M2Crypto>=0.21.1',
-    'm2secret>=0.1.1',
+    'cryptography>=0.9.2',
 ]
+entry_points = {
+    'console_scripts': [
+        'encrypted-cookies-keygen=encrypted_cookies.keygen:main',
+    ],
+}
 
 
 def get_version(package):
@@ -73,5 +77,6 @@ setup(
     author_email=author_email,
     packages=get_packages(package),
     package_data=get_package_data(package),
-    install_requires=install_requires
+    install_requires=install_requires,
+    entry_points=entry_points,
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ author_email = 'francis@bright-interactive.co.uk'
 license = 'BSD'
 install_requires = [
     'Django>=1.4',
-    'cryptography>=0.9.2',
+    'cryptography>=0.7',
 ]
 entry_points = {
     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ author_email = 'francis@bright-interactive.co.uk'
 license = 'BSD'
 install_requires = [
     'Django>=1.4',
+    'cryptography>=0.9.2',
 ]
 entry_points = {
     'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ author_email = 'francis@bright-interactive.co.uk'
 license = 'BSD'
 install_requires = [
     'Django>=1.4',
-    'cryptography>=0.9.2',
 ]
 entry_points = {
     'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,13 @@ deps=
     mock
     cryptography>=0.9.2
 
+    # M2Crypto>=0.22.3 is not working for me currently,
+    # even with a swig downgrade.
+    # See https://github.com/martinpaljak/M2Crypto/issues/60
+    M2Crypto==0.21.1
+
+    m2secret>=0.1.1
+
 [django14]
 deps=
     Django>=1.4,<1.5

--- a/tox.ini
+++ b/tox.ini
@@ -20,13 +20,6 @@ deps=
     mock
     cryptography>=0.9.2
 
-    # M2Crypto>=0.22.3 is not working for me currently,
-    # even with a swig downgrade.
-    # See https://github.com/martinpaljak/M2Crypto/issues/60
-    M2Crypto==0.21.1
-
-    m2secret>=0.1.1
-
 [django14]
 deps=
     Django>=1.4,<1.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,24 @@
 [tox]
 envlist=
-    py26-django14-m2c,
-    py27-django14-m2c,
-    py26-django15-m2c,
-    py27-django15-m2c,
-    py27-django15-m2c-noparanoia,
+    # Test all versions of Django using Python 2.7:
+    py27-django14,
+    py27-django15,
+    py27-django16,
+    py27-django17,
+    py27-django18,
+
+    # Test the last version of Django to support Python 2.6.
+    py26-django16,
 
 [testenv]
+basepython=python2.7
 commands=
     python manage.py test --traceback
 
 [base]
-deps= mock
-
-[paranoia]
-deps= django-paranoia>=0.1.8.6
-
-[m2c]
 deps=
-    M2Crypto>=0.21.1
-    m2secret>=0.1.1
+    mock
+    cryptography>=0.9.2
 
 [django14]
 deps=
@@ -31,38 +30,42 @@ deps=
     Django>=1.5,<1.6
     {[base]deps}
 
-[testenv:py26-django14-m2c]
+[django16]
+deps=
+    Django>=1.6,<1.7
+    {[base]deps}
+
+[django17]
+deps=
+    Django>=1.7,<1.8
+    {[base]deps}
+
+[django18]
+deps=
+    Django>=1.8,<1.9
+    {[base]deps}
+
+
+# Matrix of Django versions:
+
+[testenv:py27-django14]
+deps={[django14]deps}
+
+[testenv:py27-django15]
+deps={[django15]deps}
+
+[testenv:py27-django16]
+deps={[django16]deps}
+
+[testenv:py27-django17]
+deps={[django17]deps}
+
+[testenv:py27-django18]
+deps={[django18]deps}
+
+
+# Test the last Django to support Python 2.6:
+
+[testenv:py26-django16]
 basepython=python2.6
-deps=
-    {[django14]deps}
-    {[m2c]deps}
-    {[paranoia]deps}
-
-[testenv:py27-django14-m2c]
-basepython=python2.7
-deps=
-    {[django14]deps}
-    {[m2c]deps}
-    {[paranoia]deps}
-
-[testenv:py26-django15-m2c]
-basepython=python2.6
-deps=
-    {[django15]deps}
-    {[m2c]deps}
-    {[paranoia]deps}
-
-[testenv:py27-django15-m2c]
-basepython=python2.7
-deps=
-    {[django15]deps}
-    {[m2c]deps}
-    {[paranoia]deps}
-
-# Smoke test to make sure nothing breaks
-# when django-paranoia is removed.
-[testenv:py27-django15-m2c-noparanoia]
-basepython=python2.7
-deps=
-    {[django15]deps}
-    {[m2c]deps}
+deps={[django16]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,10 @@ commands=
 
 [base]
 deps=
-    mock
+    # Pinned this version of mock because newer ones do not support Python 2.6
+    mock==1.0.0
+    # Only cryptography 0.7 or higher is needed but this feature was
+    # developed against 0.9.2 in case a future version breaks the tests.
     cryptography>=0.9.2
 
 [django14]


### PR DESCRIPTION
The cryptography library is easier to deal with and better maintained than M2Crypto. There are a few other changes in here which are listed in the changelog.