### PR TITLE
Updates for Django 4+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,33 @@ sudo: false
 language: python
 python: 2.7
 env:
-    - TOX_ENV=py26-django16
-    - TOX_ENV=py27-django14
-    - TOX_ENV=py27-django15
-    - TOX_ENV=py27-django16
-    - TOX_ENV=py27-django17
-    - TOX_ENV=py27-django18
-    - TOX_ENV=py27-django19
-    - TOX_ENV=py33-django16
-    - TOX_ENV=py33-django17
-    - TOX_ENV=py33-django18
-    - TOX_ENV=py34-django16
-    - TOX_ENV=py34-django17
-    - TOX_ENV=py34-django18
-    - TOX_ENV=py34-django19
+    - TOX_ENV=py310-django42
+    - TOX_ENV=py310-django50
+    - TOX_ENV=py310-django51
+    - TOX_ENV=py310-django52
+    - TOX_ENV=py311-django42
+    - TOX_ENV=py311-django50
+    - TOX_ENV=py311-django51
+    - TOX_ENV=py311-django52
+    - TOX_ENV=py312-django42
+    - TOX_ENV=py312-django50
+    - TOX_ENV=py312-django51
+    - TOX_ENV=py312-django52
+    - TOX_ENV=py312-django60
+    - TOX_ENV=py313-django51
+    - TOX_ENV=py313-django52
+    - TOX_ENV=py313-django60
+    - TOX_ENV=py314-django52
+    - TOX_ENV=py314-django60
 matrix:
     fast_finish: true
     include:
-        - python: 3.5
-          env: TOX_ENV=py35-django18
-        - python: 3.5
-          env: TOX_ENV=py35-django19
+        - python: 3.12
+          env: TOX_ENV=py312-django42
+        - python: 3.14
+          env: TOX_ENV=py314-django52
+        - python: 3.14
+          env: TOX_ENV=py314-django60
 install:
     - pip install tox
 script:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Adding it to your Django Project
 Here are some installation commands you can follow using the
 [pip](http://www.pip-installer.org/) installer.
 You'll need
-[Django](https://djangoproject.com/) 1.4.x or greater (tested through 1.9)
+[Django](https://djangoproject.com/) 4.2.x or greater (tested through 6.0)
 and [cryptography](https://cryptography.io/en/latest/)
 which are both automatically installed for you.
-Python 2.6, 2.7, 3.3, 3.4, and 3.5 are supported.
+All python versions supported by the respective Django release are supported.
 
 Install the module and its dependencies with pip:
 
@@ -60,6 +60,10 @@ Optionally, you can opt to use JSON for serialization, rather
 than the default (pickle):
 
     ENCRYPTED_COOKIE_SERIALIZER = 'json'
+
+Note that starting with Django 5.0, the pickle serializer is no longer
+available. `django-encrypted-cookie-session` will default to json on
+those versions.
 
 Key Rotation
 ============
@@ -191,8 +195,7 @@ Running the tests
 
 To run the tests against multiple environments, install
 [tox](http://tox.readthedocs.org/) using
-`pip install tox`. You need at least Python 2.7 to run tox itself but you'll
-need 2.6 as well to run all environments. Run the tests like this:
+`pip install tox`. Run the tests like this:
 
     tox
 
@@ -205,11 +208,11 @@ like this:
 
 To run the tests against a single environment:
 
-    tox -e py27-django18
+    tox -e py314-django60
 
 To debug something weird, run it directly from the virtualenv like:
 
-    .tox/py27-django18/bin/python manage.py test
+    .tox/py314-django60/bin/python manage.py test
 
 Changelog
 =========

--- a/encrypted_cookies/__init__.py
+++ b/encrypted_cookies/__init__.py
@@ -18,10 +18,7 @@ except ImportError:
 
 from django.core import signing
 
-try:
-    from django.utils.six.moves import cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 
 from cryptography.fernet import InvalidToken
 

--- a/encrypted_cookies/__init__.py
+++ b/encrypted_cookies/__init__.py
@@ -10,11 +10,12 @@ from django.core.exceptions import ImproperlyConfigured
 from django.contrib.sessions.serializers import JSONSerializer
 
 try:
-    # Django 1.5.x support
+    # Django 4.x only
     from django.contrib.sessions.serializers import PickleSerializer
+    pickle_available=True
 except ImportError:
-    # Legacy Django support
-    from django.contrib.sessions.backends.signed_cookies import PickleSerializer
+    pickle_available=False
+
 from django.core import signing
 
 try:
@@ -71,7 +72,10 @@ class EncryptingJSONSerializer(BaseEncryptingSerializer):
         self._serializer = JSONSerializer()
 
 
-_DEFAULT_SERIALIZER = 'pickle'
+if pickle_available:
+    _DEFAULT_SERIALIZER = 'pickle'
+else:
+    _DEFAULT_SERIALIZER = 'json'
 
 def EncryptingSerializer():
     # use the default if unset, or set to any Falsey value

--- a/encrypted_cookies/__init__.py
+++ b/encrypted_cookies/__init__.py
@@ -7,13 +7,8 @@ import zlib
 import django.contrib.sessions.backends.signed_cookies
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.contrib.sessions.serializers import JSONSerializer
 
-try:
-    # Django 1.5.x support
-    from django.contrib.sessions.serializers import JSONSerializer
-except ImportError:
-    # Legacy Django support
-    from django.core.signing import JSONSerializer
 try:
     # Django 1.5.x support
     from django.contrib.sessions.serializers import PickleSerializer

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ author = 'Bright Interactive'
 author_email = 'francis@bright-interactive.co.uk'
 license = 'BSD'
 install_requires = [
-    'Django>=1.4',
-    'cryptography>=0.7',
+    'Django>=4.2',
+    'cryptography>=36',
 ]
 entry_points = {
     'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,45 +1,27 @@
 [tox]
 # Whenever you update this list, also update TOX_ENV in .travis.yml
 envlist =
-    # Django 1.8 and up support Python 3.5:
-    py35-django{18,19},
-
-    # Django 1.6 and up support Python 3.4:
-    py34-django{16,17,18,19},
-
-    # Django 1.6 through 1.8 support Python 3.3:
-    py33-django{16,17,18},
-
-    # Test all versions of Django using Python 2.7:
-    py27-django{14,15,16,17,18,19},
-
-    # Test only the final supported version on Python 2.6:
-    py26-django{16},
+    py310-django{42,50,51,52}
+    py311-django{42,50,51,52}
+    py312-django{42,50,51,52,60}
+    py313-django{51,52,60}
+    py314-django{52,60}
 
 [testenv]
 basepython =
-    py26: python2.6
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
-commands =
-    py26,py27: python manage.py test --traceback
-    # In Python 3, issue errors when mixing bytes/str
-    py33,py34,py35: python -bb manage.py test --traceback
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
+    py313: python3.13
+    py314: python3.14
+commands = python manage.py test --traceback
 deps =
-    # Only cryptography 0.7 or higher is needed but this feature was
-    # developed against 0.9.2 in case a future version breaks the tests.
-    cryptography>=0.9.2
-    # Python 3.3 and above include mock as unittest.mock
-    py27: mock
-    # Pin this version of mock because newer ones do not support Python 2.6
-    py26: mock==1.0.0
-    django14: Django>=1.4,<1.5
-    django15: Django>=1.5,<1.6
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
+    cryptography>=36
+    django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
+    django60: Django>=6.0,<6.1
+
 setenv =
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
This is a small overhaul of the package.

It updates it to work with currently supported Django versions (4.2-6.0) and respective python versions.
As a side effect, this fixes #25.

Please let me know if I should add a changelog entry as well.